### PR TITLE
Fix TS issues and add success toast style

### DIFF
--- a/client/src/components/ui/toast.tsx
+++ b/client/src/components/ui/toast.tsx
@@ -30,6 +30,8 @@ const toastVariants = cva(
         default: "border bg-white text-foreground",
         destructive:
           "border border-red-100 bg-red-50 text-red-800",
+        success:
+          "border border-green-100 bg-green-50 text-green-800",
       },
     },
     defaultVariants: {

--- a/client/src/lib/emailGenerator.ts
+++ b/client/src/lib/emailGenerator.ts
@@ -313,7 +313,8 @@ export function generateEmails(
       // Set the reply-to as the user's email so replies go to them
       replyTo: replyToEmail,
       subject: `Seeking ${category} assistance for my ${relationship}`,
-      body: `${emailBody}\n\n[TEST EMAIL] Original recipient: ${templateResource.email} (${templateResource.name})`
+      body: `${emailBody}\n\n[TEST EMAIL] Original recipient: ${templateResource.email} (${templateResource.name})`,
+      category
     });
   });
   

--- a/client/src/lib/useWizardState.ts
+++ b/client/src/lib/useWizardState.ts
@@ -13,6 +13,7 @@ export interface EmailTemplate {
   replyTo?: string; // User's actual email for replies
   subject: string;
   body: string;
+  category?: string;
 }
 
 // Interface for the global wizard state

--- a/client/src/pages/EmailPreview.tsx
+++ b/client/src/pages/EmailPreview.tsx
@@ -319,7 +319,20 @@ export default function EmailPreview() {
               </div>
               
               <div className="flex items-center gap-3">
-                <NylasConnect userEmail={currentEmail?.replyTo || state.answers?.q14?.email} />
+                {(() => {
+                  let fallbackEmail: string | undefined = undefined;
+                  try {
+                    if (state.answers?.q14) {
+                      const info = JSON.parse(state.answers.q14 as string);
+                      fallbackEmail = info.email;
+                    }
+                  } catch {
+                    // ignore JSON parse errors
+                  }
+                  return (
+                    <NylasConnect userEmail={currentEmail?.replyTo || fallbackEmail} />
+                  );
+                })()}
                 <NylasGrantIdSetter />
                 
                 <div className="px-4 py-2 backdrop-blur-sm rounded-full text-sm font-medium text-gray-600">

--- a/server/nylas-sdk-v3.d.ts
+++ b/server/nylas-sdk-v3.d.ts
@@ -1,0 +1,13 @@
+export interface EmailData {
+  to: string
+  subject: string
+  body: string
+  replyTo?: string
+}
+
+export function generateNylasAuthUrl(email: string, callbackUrl: string): string
+export function exchangeCodeForToken(code: string, redirectUri: string): Promise<string>
+export function checkNylasConnection(grantId: string): Promise<boolean>
+export function createFolderStructure(grantId: string): Promise<{ success: boolean; folderIds?: Record<string, string>; error?: string }>
+export function sendEmailWithNylas(grantId: string, emailData: EmailData, category: string): Promise<{ success: boolean; messageId?: string | null; error?: any }>
+export function getMessagesFromCategory(grantId: string, category: string, limit?: number): Promise<any[]>

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -6,7 +6,7 @@ import { type Server } from "http";
 import viteConfigFunction from "../vite.config";
 import { nanoid } from "nanoid";
 
-const viteLogger = createLogger();
+const viteLogger = createLogger(undefined);
 
 export function log(message: string, source = "express") {
   const formattedTime = new Date().toLocaleTimeString("en-US", {
@@ -20,13 +20,19 @@ export function log(message: string, source = "express") {
 }
 
 export async function setupVite(app: Express, server: Server) {
-  const serverOptions = {
+  const serverOptions: import("vite").ServerOptions = {
     middlewareMode: true,
     hmr: { server },
-    allowedHosts: true,
+    allowedHosts: true as const,
   };
 
-  const resolvedViteConfig = await viteConfigFunction(); // Call the async function to get the config object
+  const resolvedViteConfig =
+    typeof viteConfigFunction === "function"
+      ? await viteConfigFunction({
+          command: "serve",
+          mode: process.env.NODE_ENV || "development",
+        })
+      : viteConfigFunction;
 
   const vite = await createViteServer({
     ...resolvedViteConfig,


### PR DESCRIPTION
## Summary
- add success variant for toast component
- support category in email templates and generator
- parse stored contact JSON when loading fallback email address
- fix send-batch-emails route variable scope and type issues
- update Vite server setup typings
- provide TypeScript declarations for Nylas SDK

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_683f5739fbdc832dad7281019d4becdf