### PR TITLE
Fix hub navigation routes

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -40,6 +40,10 @@ function Router() {
       <Route path="/email-setup" component={EmailSetup} />
       <Route path="/email-connect" component={EmailConnect} />
       <Route path="/home" component={CommunicationHub} />
+      <Route path="/emails/:category/:status" component={CommunicationHub} />
+      <Route path="/email/:id" component={CommunicationHub} />
+      <Route path="/documents" component={CommunicationHub} />
+      <Route path="/map" component={CommunicationHub} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/client/src/hub/pages/EmailDetail.tsx
+++ b/client/src/hub/pages/EmailDetail.tsx
@@ -86,8 +86,8 @@ const EmailDetail = () => {
               Browse All Emails
             </Button>
             
-            <Button 
-              onClick={() => navigate('/')}
+            <Button
+              onClick={() => navigate('/home')}
               variant="outline"
               className="w-full"
             >

--- a/client/src/hub/pages/IndexActionButtons.tsx
+++ b/client/src/hub/pages/IndexActionButtons.tsx
@@ -15,7 +15,7 @@ const IndexActionButtons = ({ onNewEmail, onViewDocuments, onCalendarClick }: In
   return (
     <div className="flex items-center justify-center gap-8">
       <button
-        onClick={() => navigate('/')}
+        onClick={() => navigate('/home')}
         className="flex items-center gap-2 text-gray-700 hover:text-blue-600 transition-colors duration-200 text-base font-normal underline decoration-gray-400 hover:decoration-blue-600 underline-offset-4"
       >
         <Home className="h-4 w-4" />

--- a/client/src/pages/CommunicationHub.tsx
+++ b/client/src/pages/CommunicationHub.tsx
@@ -23,7 +23,7 @@ export default function CommunicationHub() {
         <DndProvider backend={HTML5Backend}>
           <UserRoleProvider defaultRole="primary-caregiver">
             <Toaster />
-            <BrowserRouter basename="/home">
+            <BrowserRouter>
               <Routes>
                 <Route path="/" element={<Index />} />
                 <Route path="/emails/:category/:status" element={<EmailList />} />


### PR DESCRIPTION
## Summary
- remove `/home` basename from CommunicationHub router so internal links use plain paths
- update buttons that navigated to `/` to go to `/home`
- expose hub routes (`/emails/...`, `/documents`, `/map`) in the main router

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node', 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6841a0e0a52c832dad45597dc542169f