### PR TITLE
Fix /home routing bug

### DIFF
--- a/client/src/pages/CommunicationHub.tsx
+++ b/client/src/pages/CommunicationHub.tsx
@@ -26,6 +26,8 @@ export default function CommunicationHub() {
             <BrowserRouter>
               <Routes>
                 <Route path="/" element={<Index />} />
+                {/* Support direct navigation to /home */}
+                <Route path="/home" element={<Index />} />
                 <Route path="/emails/:category/:status" element={<EmailList />} />
                 <Route path="/email/:id" element={<EmailDetail />} />
                 <Route path="/documents" element={<Documents />} />


### PR DESCRIPTION
## Summary
- ensure `/home` route correctly renders the Communication Hub index page

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6841a3ffbc38832dbf908da3ec7e9db4