### PR TITLE
Add session auth with Passport

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,6 +11,7 @@ import Results from "@/pages/Results";
 import CleanResults from "@/pages/CleanResults";
 import CleanResultsPage from "@/pages/CleanResultsPage";
 import EmailPreview from "@/pages/EmailPreview";
+import Login from "@/pages/Login";
 import Callback from "@/pages/Callback";
 import Confirmation from "@/pages/Confirmation";
 import AdminDashboard from "@/pages/Admin";
@@ -31,6 +32,7 @@ function Router() {
       <Route path="/clean-results" component={CleanResults} />
       <Route path="/clean-results-page" component={CleanResultsPage} />
       <Route path="/email-preview/:index?" component={EmailPreview} />
+      <Route path="/login" component={Login} />
       <Route path="/callback" component={Callback} />
       <Route path="/confirmation" component={Confirmation} />
       <Route path="/admin" component={AdminDashboard} />

--- a/client/src/pages/CleanResults.tsx
+++ b/client/src/pages/CleanResults.tsx
@@ -104,7 +104,7 @@ export default function CleanResults() {
   };
 
   // Handle continue button
-  const handleContinue = () => {
+  const handleContinue = async () => {
     console.log("Continue button clicked");
 
     if (state.selectedResourceIds.length === 0) {
@@ -131,8 +131,17 @@ export default function CleanResults() {
         currentEmailIndex: 0,
       });
 
-      // Navigate to email preview
-      window.location.href = "/email-preview/0";
+      try {
+        const res = await fetch('/api/auth/status', { credentials: 'include' });
+        const data = await res.json();
+        if (data.user) {
+          window.location.href = "/email-preview/0";
+        } else {
+          window.location.href = `/login?next=${encodeURIComponent('/email-preview/0')}`;
+        }
+      } catch {
+        window.location.href = `/login?next=${encodeURIComponent('/email-preview/0')}`;
+      }
     } catch (error) {
       console.error("Error in handleContinue:", error);
       toast({

--- a/client/src/pages/EmailPreview.tsx
+++ b/client/src/pages/EmailPreview.tsx
@@ -61,6 +61,16 @@ export default function EmailPreview() {
   const [emailBody, setEmailBody] = useState('');
   const [showSendAllOption, setShowSendAllOption] = useState(false);
   const [isSendingAll, setIsSendingAll] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/auth/status', { credentials: 'include' })
+      .then(res => res.json())
+      .then(data => {
+        if (!data.user) {
+          navigate(`/login?next=${encodeURIComponent(window.location.pathname)}`);
+        }
+      });
+  }, []);
   
   // Get the current email index
   const currentIndex = parseInt(index, 10);

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import { useLocation } from 'wouter';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { useToast } from '@/hooks/use-toast';
+
+export default function Login() {
+  const [_, navigate] = useLocation();
+  const { toast } = useToast();
+  const params = new URLSearchParams(window.location.search);
+  const next = params.get('next') || '/';
+  const [isRegister, setIsRegister] = useState(false);
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const endpoint = isRegister ? '/api/auth/register' : '/api/auth/login';
+    try {
+      const res = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ username, password }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        navigate(next);
+      } else {
+        toast({ title: 'Error', description: data.message || 'Failed', variant: 'destructive' });
+      }
+    } catch {
+      toast({ title: 'Error', description: 'Network error', variant: 'destructive' });
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto p-4 space-y-4">
+      <h1 className="text-2xl font-semibold text-center">{isRegister ? 'Create Account' : 'Login'}</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <Label htmlFor="username">Email</Label>
+          <Input id="username" type="email" value={username} onChange={e => setUsername(e.target.value)} required />
+        </div>
+        <div>
+          <Label htmlFor="password">Password</Label>
+          <Input id="password" type="password" value={password} onChange={e => setPassword(e.target.value)} required />
+        </div>
+        <Button type="submit" className="w-full">{isRegister ? 'Register' : 'Login'}</Button>
+      </form>
+      <Button variant="secondary" className="w-full" onClick={() => { window.location.href = `/api/auth/google?next=${encodeURIComponent(next)}`; }}>Sign in with Google</Button>
+      <p className="text-center text-sm">
+        {isRegister ? 'Already have an account?' : "Don't have an account?"}{' '}
+        <button className="underline" onClick={() => setIsRegister(!isRegister)}>{isRegister ? 'Login' : 'Create one'}</button>
+      </p>
+    </div>
+  );
+}

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,0 +1,65 @@
+import passport from 'passport';
+import { Strategy as LocalStrategy } from 'passport-local';
+import { Strategy as GoogleStrategy } from 'passport-google-oauth20';
+import bcrypt from 'bcryptjs';
+import { storage } from './storage';
+
+passport.use(new LocalStrategy(async (username, password, done) => {
+  try {
+    const user = await storage.getUserByUsername(username);
+    if (!user) {
+      return done(null, false, { message: 'Incorrect username' });
+    }
+    const match = await bcrypt.compare(password, user.password);
+    if (!match) {
+      return done(null, false, { message: 'Incorrect password' });
+    }
+    return done(null, user);
+  } catch (err) {
+    return done(err);
+  }
+}));
+
+passport.use(new GoogleStrategy(
+  {
+    clientID: process.env.GOOGLE_CLIENT_ID || '',
+    clientSecret: process.env.GOOGLE_CLIENT_SECRET || '',
+    callbackURL: '/api/auth/google/callback',
+  },
+  async (_accessToken: string, _refreshToken: string, profile: any, done: any) => {
+    try {
+      const email = profile.emails && profile.emails[0]?.value;
+      if (!email) {
+        return done(null, false, { message: 'No email from Google' });
+      }
+      let user = await storage.getUserByUsername(email);
+      if (!user) {
+        const hashed = await bcrypt.hash(Math.random().toString(36), 10);
+        user = await storage.createUser({ username: email, password: hashed, email });
+      }
+      done(null, user);
+    } catch (err) {
+      done(err);
+    }
+  }
+));
+
+passport.serializeUser((user: any, done) => {
+  done(null, user.id);
+});
+
+passport.deserializeUser(async (id: number, done) => {
+  try {
+    const user = await storage.getUser(id);
+    done(null, user || null);
+  } catch (err) {
+    done(err);
+  }
+});
+
+export function ensureAuthenticated(req: any, res: any, next: any) {
+  if (req.isAuthenticated && req.isAuthenticated()) {
+    return next();
+  }
+  res.status(401).json({ error: 'Not authenticated' });
+}

--- a/server/authRoutes.ts
+++ b/server/authRoutes.ts
@@ -1,0 +1,68 @@
+import { Router } from 'express';
+import passport from 'passport';
+import bcrypt from 'bcryptjs';
+import { storage } from './storage';
+
+const router = Router();
+
+router.get('/auth/status', (req, res) => {
+  if (req.user) {
+    const user = req.user as any;
+    res.json({ user: { id: user.id, username: user.username } });
+  } else {
+    res.json({ user: null });
+  }
+});
+
+router.post('/auth/register', async (req, res) => {
+  const { username, password } = req.body;
+  if (!username || !password) {
+    return res.status(400).json({ message: 'Username and password required' });
+  }
+  try {
+    const existing = await storage.getUserByUsername(username);
+    if (existing) {
+      return res.status(400).json({ message: 'User already exists' });
+    }
+    const hashed = await bcrypt.hash(password, 10);
+    const user = await storage.createUser({ username, password: hashed, email: username });
+    req.login(user, err => {
+      if (err) { return res.status(500).json({ message: 'Login failed' }); }
+      res.json({ user: { id: user.id, username: user.username } });
+    });
+  } catch (err) {
+    res.status(500).json({ message: 'Registration failed' });
+  }
+});
+
+router.post('/auth/login', (req, res, next) => {
+  passport.authenticate('local', (err: any, user: any, info: any) => {
+    if (err) { return next(err); }
+    if (!user) { return res.status(401).json({ message: info?.message || 'Login failed' }); }
+    req.login(user, (err2: any) => {
+      if (err2) { return next(err2); }
+      res.json({ user: { id: (user as any).id, username: (user as any).username } });
+    });
+  })(req, res, next);
+});
+
+router.post('/auth/logout', (req, res, next) => {
+  req.logout((err: any) => {
+    if (err) return next(err);
+    res.json({ success: true });
+  });
+});
+
+router.get('/auth/google', (req, res, next) => {
+  const redirect = req.query.next as string | undefined;
+  if (redirect) req.session!.redirectTo = redirect;
+  passport.authenticate('google', { scope: ['profile', 'email'] })(req, res, next);
+});
+
+router.get('/auth/google/callback', passport.authenticate('google', { failureRedirect: '/login' }), (req, res) => {
+  const to = req.session!.redirectTo || '/';
+  delete req.session!.redirectTo;
+  res.redirect(to);
+});
+
+export default router;

--- a/server/index.ts
+++ b/server/index.ts
@@ -6,6 +6,8 @@ import connectPgSimple from 'connect-pg-simple';
 import { pool } from './db';
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
+import passport from 'passport';
+import './auth';
 
 const app = express();
 app.set('trust proxy', 1); // trust first proxy for secure cookies
@@ -27,12 +29,15 @@ app.use(session({
   secret: process.env.SESSION_SECRET || 'askedith-secret-key',
   resave: false,
   saveUninitialized: false,
-  cookie: { 
+  cookie: {
     secure: process.env.NODE_ENV === 'production',
     maxAge: 24 * 60 * 60 * 1000, // 24 hours
     sameSite: 'lax',
   }
 }));
+
+app.use(passport.initialize());
+app.use(passport.session());
 
 app.use((req, res, next) => {
   const start = Date.now();

--- a/server/nylasRoutes.ts
+++ b/server/nylasRoutes.ts
@@ -13,6 +13,7 @@ import {
   getMessagesFromCategory
 } from './nylas-sdk-v3';
 import type { EmailData } from './nylas-sdk-v3';
+import { ensureAuthenticated } from './auth';
 
 const router = Router();
 
@@ -94,7 +95,7 @@ router.post("/nylas/manual-exchange", async (req: Request, res: Response) => {
 
 
 // Check connection status
-router.get('/nylas/connection-status', async (req: Request, res: Response) => {
+router.get('/nylas/connection-status', ensureAuthenticated, async (req: Request, res: Response) => {
   if (!req.session?.nylasGrantId) {
     return res.json({ connected: false });
   }
@@ -109,7 +110,7 @@ router.get('/nylas/connection-status', async (req: Request, res: Response) => {
 });
 
 // Send email via Nylas (This endpoint is used by client if a connection is established)
-router.post('/nylas/send-email', async (req: Request, res: Response) => {
+router.post('/nylas/send-email', ensureAuthenticated, async (req: Request, res: Response) => {
   const grantId = req.session?.nylasGrantId;
   
   if (!grantId) {
@@ -151,7 +152,7 @@ router.post('/nylas/send-email', async (req: Request, res: Response) => {
 });
 
 // Get messages from a specific category
-router.get('/nylas/messages/:category', async (req: Request, res: Response) => {
+router.get('/nylas/messages/:category', ensureAuthenticated, async (req: Request, res: Response) => {
   const grantId = req.session?.nylasGrantId;
   
   if (!grantId) {
@@ -175,7 +176,7 @@ router.get('/nylas/messages/:category', async (req: Request, res: Response) => {
 });
 
 // Send batch emails through Nylas
-router.post('/nylas/send-batch', async (req: Request, res: Response) => {
+router.post('/nylas/send-batch', ensureAuthenticated, async (req: Request, res: Response) => {
   const grantId = req.session?.nylasGrantId;
   
   if (!grantId) {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3,6 +3,7 @@ import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import path from "path";
 import express from "express";
+import authRoutes from "./authRoutes";
 
 export async function registerRoutes(app: Express): Promise<Server> {
   // Serve static assets from public directory
@@ -15,6 +16,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
   } catch (error) {
     console.error('Failed to load Nylas routes:', error);
   }
+
+  app.use('/api', authRoutes);
   
   // API endpoint to provide Mapbox public key to frontend
   app.get("/api/mapbox-key", (req, res) => {

--- a/server/types/express-session.d.ts
+++ b/server/types/express-session.d.ts
@@ -6,5 +6,6 @@ declare module 'express-session' {
     username?: string;
     nylasAccessToken?: string; // For backward compatibility
     nylasGrantId?: string; // New V3 Nylas grant ID
+    redirectTo?: string;
   }
 }

--- a/server/types/passport-google-oauth20.d.ts
+++ b/server/types/passport-google-oauth20.d.ts
@@ -1,0 +1,1 @@
+declare module 'passport-google-oauth20';


### PR DESCRIPTION
## Summary
- implement `passport` local and Google strategies
- add `/api/auth` routes for login, register, logout and status
- initialise passport session in Express server
- protect Nylas email endpoints with authentication
- add login page and guard email preview
- require authentication after selecting results

## Testing
- `npm run check` *(fails: Cannot find module '@/pages/Callback' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68436ed85300832db9b425ddee3200a9